### PR TITLE
Add lsstcam-jupyterlab option

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -102,6 +102,7 @@ attributes:
       - [ "neutrino-jupyter/latest", "export SINGULARITY_IMAGE_PATH=/sdf/group/neutrino/images/latest.sif \nexport PYTHONPATH=\"\"\nfunction jupyter() { singularity exec --nv -B /sdf,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@ ; }" ]
       - [ "neutrino-jupyter/2021-06-05", "export SINGULARITY_IMAGE_PATH=/sdf/group/neutrino/images/larcv2_ub20.04-cuda11.0-pytorch1.7.1-edepsim.sif \nexport PYTHONPATH=\"\"\nfunction jupyter() { singularity exec --nv -B /sdf,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@ ; }" ]
       - [ "neutrino-jupyter/2021-01-27", "export SINGULARITY_IMAGE_PATH=/sdf/group/neutrino/images/larcv2_ub18.04-cuda10.2-pytorch1.7.1-edepsim.sif \nexport PYTHONPATH=\"\"\nfunction jupyter() { singularity exec --nv -B /sdf,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@ ; }" ]
+      - [ "lsstcam-jupyterlab", "source /sdf/group/lsst/software/conda/bin/activate lsstcam-jupyterlab" ]
       - [ "lsst/r18_1_0",  "module load lsst/r18_1_0" ]
       - [ "lsst/r19_0_0",  "module load lsst/r19_0_0" ]
       - [ "nexo/chroma", "export SINGULARITY_IMAGE_PATH=/sdf/group/nexo/software/chroma/Chroma_latest.sif\nfunction jupyter() { singularity exec --nv -B /sdf,/gpfs,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@; }" ]


### PR DESCRIPTION
Creates a generic lsstcam-jupyterlab option. LSST software is available via kernels installed under the conda installation's share directory