### PR TITLE
Fixing submit.yml.erb For slurm account

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -12,7 +12,7 @@ batch_connect:
 script:
   native:
     - "-p<%= slurm_partition %>"
-    - "-A<%= slurm_partition %>"
+    - "-A<%= slurm_account %>"
     - "-N1"
     - "-c<%= num_cores %>"
     - "--mem=<% if mem == "" %>1024<% else %><%= mem %><% end %>"


### PR DESCRIPTION
fixing the -A paramter on submit.yml.erb file to get the correct form value: "slurm_account"