### PR TITLE
Add ability for user to specify generic sbatch options

### DIFF
--- a/form.js
+++ b/form.js
@@ -242,6 +242,7 @@ function set_cluster_group_handler() {
   toggle_visibility_of_form_group( "#batch_connect_session_context_num_cores", batch );
   toggle_visibility_of_form_group( "#batch_connect_session_context_mem", batch );
   toggle_visibility_of_form_group( "#batch_connect_session_context_num_gpus", batch );
+  toggle_visibility_of_form_group( "#batch_connect_session_context_sbatch_options", batch );
 
 }
 

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -14,6 +14,7 @@ form:
   - num_cores
   - mem
   - num_gpus
+  - sbatch_options
   - bc_email_on_started
 attributes:
   commands:
@@ -69,6 +70,10 @@ attributes:
       Slurm [Account] to launch Jupyter job on
 
       [Account]: https:///public/doc/#/batch-compute?id=partitions-amp-accounts
+  sbatch_options:
+    label: "Options"
+    help: |
+      String of additional sbatch options
   slurm_partition:
     label: "Partition"
     help: |

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -7,7 +7,8 @@ batch_connect:
 script:
   native:
     - "-p<%= slurm_partition %>"
-    - "-A<%= slurm_partition %>"
+    - "-A<%= slurm_account %>"
+    - "<%= sbatch_options %>"
     - "-N1"
     - "-c<%= num_cores %>"
     - "--mem=<% if mem == "" %>1024<% else %><%= mem %><% end %>"


### PR DESCRIPTION
When starting a notebook with slurm (e.g. to use a reservation).  Also fixes a cut-and-paste bug with the account (-A) option  which was using slurm_partition instead of slurm_account.

I am not an expert in this embedded-ruby (.erb) and javascript but I created the new pattern by copying the pattern for the slurm_account parameter which is also a string.  Since I am a non-expert there is a chance there are bugs with my changes (in particular I don't know if it behaves correctly if the user doesn't specify any sbatch options).