### PR TITLE
Update form.yml.erb

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -119,7 +119,7 @@ attributes:
       -
         - slac/20211101.0
         - |
-              export SINGULARITY_IMAGE_PATH=/fs/ddn/sdf/group/ml/software/images/slac-ml/20211101.0/slac-ml@20211101.0.sif
+              export SINGULARITY_IMAGE_PATH=/sdf/group/lcls/ds/tools/software/images/slac-ml/20211101.0/slac-ml@20211101.0.sif
               function jupyter() { singularity exec --nv -B /sdf,/fs,/sdf/scratch/,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@; }
       -
         - LCLS/LCLS1-py3
@@ -136,7 +136,7 @@ attributes:
       -
         - slac/SSAI
         - |
-              export SINGULARITY_IMAGE_PATH=/fs/ddn//sdf/group/ml/datasets/images/shared.sif
+              export SINGULARITY_IMAGE_PATH=/sdf/group/mli/datasets/images/shared.sif
               export PYTHONPATH=\"\"
               function jupyter() { singularity exec --nv -B /sdf,/fs,/lscratch ${SINGULARITY_IMAGE_PATH} jupyter $@ ;}
       -


### PR DESCRIPTION
changed line 122 and 139 to get images off lustre ml per discussion in https://slac.slack.com/archives/C05LJAJJDSL/p1765480724949969
It was agreed to host image slac-ml@20211101.0.sif  from /sdf/group/lcls

There was another reference for a shared.sif file in lustre ml,  Today I rsynced its 
parent dir 'images' to /sdf/group/mli/datasets  and edited to the new location
/sdf/group/mli/datasets/images/shared.sif
